### PR TITLE
Auto tagging build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: read
+      contents: write
       packages: write
 
     steps:
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: "true"
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3.0.0
         with:
@@ -27,14 +28,21 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Get next version
+        uses: reecetech/version-increment@2023.9.3
+        id: version
+        with:
+          scheme: calver
+          increment: patch
+
       - name: Extract metadata to create tags and labels
         id: meta
         uses: docker/metadata-action@v5.5.1
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=sha,enable=true,priority=100,prefix=,suffix=,format=short
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
+            type=raw,value=${{steps.version.outputs.version}},priority=300
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5.1.0
@@ -43,3 +51,14 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Create tag
+        uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/${{ steps.version.outputs.version }}',
+              sha: context.sha
+            })


### PR DESCRIPTION
This adds a workflow to auto-tag when new commits are pushed to the default branch. This will enable auto deployment on [Serubin/flux-infra](https://github.com/Serubin/flux-infra) as per https://github.com/Serubin/flux-infra/blob/main/README.md#automation--service-deployment